### PR TITLE
fix: 커서 릭 해결 및 날자 소수점 출력 처리

### DIFF
--- a/src/syncMonitor/query/target/QueryPrsLct.java
+++ b/src/syncMonitor/query/target/QueryPrsLct.java
@@ -13,7 +13,7 @@ public class QueryPrsLct {
         return "select TSN from " + config.getProSyncUser() + ".prs_lct";
     }
     public static String getLastCommitTime(DbConfig config){
-        return "select time from " + config.getProSyncUser() + ".prs_lct";
+        return "select TO_CHAR(time, 'YYYY-MM-DD HH24:MI:SS') from " + config.getProSyncUser() + ".prs_lct";
     }
 
 }

--- a/src/syncMonitor/topology/Topology.java
+++ b/src/syncMonitor/topology/Topology.java
@@ -91,10 +91,10 @@ public class Topology {
             pstmt.close();
             return response;
         }catch (SQLException e){
-            e.printStackTrace();
             return "getCommitTime Fail";
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
     }
 }
+

--- a/src/syncMonitor/topology/Topology.java
+++ b/src/syncMonitor/topology/Topology.java
@@ -51,6 +51,7 @@ public class Topology {
                 response = rSet.getInt(1);
             }
             Thread.sleep(100);
+            pstmt.close();
             return response;
         }catch (Exception e){
             return -1;
@@ -69,6 +70,7 @@ public class Topology {
                 res = rSet.getInt(1);
             }
             Thread.sleep(100);
+            pstmt.close();
             return res;
 
         } catch (Exception e) {
@@ -86,8 +88,10 @@ public class Topology {
                 response = rSet.getString(1);
             }
             Thread.sleep(100);
+            pstmt.close();
             return response;
         }catch (SQLException e){
+            e.printStackTrace();
             return "getCommitTime Fail";
         } catch (InterruptedException e) {
             throw new RuntimeException(e);

--- a/src/syncMonitor/view/View.java
+++ b/src/syncMonitor/view/View.java
@@ -56,6 +56,7 @@ public class View{
                 String targetCommitTime = null;
                 try{
                     targetCommitTime = topology.runTargetTimeQuery();
+                    //System.out.println(LocalDateTime.parse(targetCommitTime, formatter));
                 }catch (Exception e){
                     targetCommitTime = "null";
                 }
@@ -93,6 +94,7 @@ public class View{
 
             asciiTableTime.setTextAlignment(TextAlignment.CENTER);
             System.out.println(asciiTableTime.render(SIZE));
+
 
 
         } catch (Exception e) {


### PR DESCRIPTION
- pstmt 명시적 close
-  tochar활용해 시간 출력 일관성 유지